### PR TITLE
Modification description: insert() has been abolished in pymongo 4.x.

### DIFF
--- a/scrapytutorial/pipelines.py
+++ b/scrapytutorial/pipelines.py
@@ -34,7 +34,7 @@ class MongoDBPipeline(object):
 
     def process_item(self, item, spider):
         name = item.__class__.__name__
-        self.db[name].insert(dict(item))
+        self.db[name].insert_one(dict(item))
         return item
 
     def close_spider(self, spider):


### PR DESCRIPTION
Modified by: Jock

原有代码报错截图：
![2bb393dd2eb633525705c7c31a88945](https://user-images.githubusercontent.com/26761692/145709543-b30067d0-099c-4c7c-b590-8bf3d4b5e481.png)
pymongo 版本
![image](https://user-images.githubusercontent.com/26761692/145709558-c7c38a11-2585-4f95-83f1-8429d663ace4.png)

修改后执行结果：
![image](https://user-images.githubusercontent.com/26761692/145709565-3bf587fe-a9cd-4562-b644-1fb10c7f4eee.png)
